### PR TITLE
BUG: Fix hot reload for .md files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 
+- Bugfix: Get hot reload properly working with `*.md` files. (Now runs `.md` through `file-loader` and just `.mdx` through `webpack-mdx-loader`).
 - Tests: Add `autoLayout` and `template` features to `examples`. [#10](https://github.com/FormidableLabs/spectacle-cli/issues/10)
 
 ## 0.2.2

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -35,8 +35,14 @@ module.exports = {
         test: /\.jsx?$/,
         use: [babelLoader]
       },
+      // `.md` files are processed as pure text.
       {
-        test: /\.mdx?$/,
+        test: /\.md$/,
+        use: [require.resolve('raw-loader')]
+      },
+      // `.mdx` files go through babel and our mdx transforming loader.
+      {
+        test: /\.mdx$/,
         use: [babelLoader, require.resolve('../webpack-mdx-loader')]
       },
       {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
 
@@ -9,8 +8,6 @@ const WebpackDevServer = require('webpack-dev-server');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const baseCfg = require('../config/webpack.config');
-
-const readFile = promisify(fs.readFile);
 
 // Injection replacement patterns.
 const MDX_RE = /\/\/ SPECTACLE_CLI_MDX_START[\s\S]*?\/\/ SPECTACLE_CLI_MDX_END/gm;
@@ -21,9 +18,9 @@ import slides, { notes } from '${srcFilePath}';
 `;
 
 const MD_RE = /\/\/ SPECTACLE_CLI_MD_START[\s\S]*?\/\/ SPECTACLE_CLI_MD_END/gm;
-const mdTmpl = mdContent => `
+const mdTmpl = srcFilePath => `
 // SPECTACLE_CLI_MD_START
-const mdContent = ${JSON.stringify(mdContent.toString())};
+import mdContent from '${srcFilePath}';
 // SPECTACLE_CLI_MD_END
 `;
 
@@ -59,11 +56,8 @@ const webpackConfig = async ({
 }) => {
   // Use a simplified "markdown only" template for `.md` files.
   const isMd = /\.md$/.test(srcFilePath);
+  const isMdx = /\.mdx$/.test(srcFilePath);
   const tmplDir = `templates/${isMd ? 'md' : 'mdx'}-slides`;
-  let mdContent;
-  if (isMd) {
-    mdContent = await readFile(srcFilePath);
-  }
 
   // Webpack compiler + configuration.
   const entry = path.resolve(__dirname, `${tmplDir}/index.js`);
@@ -86,11 +80,11 @@ const webpackConfig = async ({
               loader: require.resolve('./webpack/inject-loader'),
               options: {
                 replacements: [
-                  !isMd
-                    ? { pattern: MDX_RE, replacement: mdxTmpl(srcFilePath) }
-                    : null,
                   isMd
-                    ? { pattern: MD_RE, replacement: mdTmpl(mdContent) }
+                    ? { pattern: MD_RE, replacement: mdTmpl(srcFilePath) }
+                    : null,
+                  isMdx
+                    ? { pattern: MDX_RE, replacement: mdxTmpl(srcFilePath) }
                     : null,
                   {
                     pattern: AUTOLAYOUT_RE,

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "gray-matter": "^4.0.2",
     "html-webpack-plugin": "^3.2.0",
     "normalize-newline": "^3.0.0",
+    "raw-loader": "^3.1.0",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "spectacle": "6.0.0-alpha.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3425,7 +3425,7 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.2.3:
+loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
@@ -4664,6 +4664,14 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+raw-loader@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-3.1.0.tgz#5e9d399a5a222cc0de18f42c3bc5e49677532b3f"
+  integrity sha512-lzUVMuJ06HF4rYveaz9Tv0WRlUMxJ0Y1hgSkkgg+50iEdaI0TthyEDe08KIHb0XsF6rn8WYTqPCaGTZg3sX+qA==
+  dependencies:
+    loader-utils "^1.1.0"
+    schema-utils "^2.0.1"
+
 rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -5036,7 +5044,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.0.0:
+schema-utils@^2.0.0, schema-utils@^2.0.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.5.0.tgz#8f254f618d402cc80257486213c8970edfd7c22f"
   integrity sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==


### PR DESCRIPTION
- Switch to a real `import` and hook up the `raw-loader` for all `.md` files.
- Make the `webpack-mdx-loaer` **only** apply to `.mdx` files.