### PR TITLE
Fix packaging

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,8 +2,9 @@
 !/bin
 !/lib
 !/config
-!/examples/cli-md
-!/examples/cli-mdx
+/examples/*
+!/examples/cli-md/
+!/examples/cli-mdx/
 !LICENSE.txt
 !README.md
 !package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## UNRELEASED
+
+- Fix `.npmrc`, removing unneeded examples. [#24](https://github.com/FormidableLabs/spectacle-cli/issues/24)
+
 ## 0.5.0
 
 - **Breaking** Remove `autoLayout` since the flex-based layout feature is intrinsic to Spectacle now.


### PR DESCRIPTION
Fixes #24 

Before:

```
$ npm pack
npm notice 
npm notice 📦  spectacle-cli@0.5.0
npm notice === Tarball Contents === 
npm notice 60B    lib/templates/boilerplate/_gitignore         
npm notice 37B    examples/cli-mdx-babel/.babelrc              
npm notice 180B   lib/templates/js-slides/index.html           
npm notice 180B   lib/templates/md-slides/index.html           
npm notice 180B   lib/templates/mdx-slides/index.html          
npm notice 3.3kB  lib/spectacle/actions.js                     
npm notice 1.9kB  bin/boilerplate/args.js                      
npm notice 2.9kB  bin/spectacle/args.js                        
npm notice 555B   bin/boilerplate/cli.js                       
npm notice 671B   bin/spectacle/cli.js                         
npm notice 324B   lib/util/file.js                             
npm notice 5.8kB  lib/templates/js-slides/index.js             
npm notice 1.1kB  lib/templates/md-slides/index.js             
npm notice 1.6kB  lib/templates/mdx-slides/index.js            
npm notice 477B   lib/webpack/inject-loader.js                 
npm notice 8.6kB  lib/boilerplate/modes.js                     
npm notice 1.4kB  lib/templates/replacements.js                
npm notice 607B   examples/cli-mdx-babel/spectacle-component.js
npm notice 723B   examples/cli-mdx-babel/template.js           
npm notice 578B   examples/cli-mdx/test-component.js           
npm notice 96B    examples/cli-mdx-babel/theme.js              
npm notice 1.2kB  config/webpack.config.cli.js                 
npm notice 1.6kB  config/webpack.config.js                     
npm notice 4.6kB  package.json                                 
npm notice 1.5kB  CHANGELOG.md                                 
npm notice 1.0kB  lib/templates/boilerplate/README.md          
npm notice 6.4kB  README.md                                    
npm notice 626B   examples/cli-md/slides.md                    
npm notice 411B   examples/cli-mdx-babel/slides.mdx            
npm notice 1.1kB  examples/cli-mdx/slides.mdx                  
npm notice 40.7kB examples/cli-mdx-babel/formidable.png        
npm notice 1.1kB  LICENSE.txt                                  
npm notice === Tarball Details === 
npm notice name:          spectacle-cli                           
npm notice version:       0.5.0                                   
npm notice filename:      spectacle-cli-0.5.0.tgz                 
npm notice package size:  52.5 kB                                 
npm notice unpacked size: 91.4 kB                                 
npm notice shasum:        8277de47c10854e5fae9681e2728128882ae12de
npm notice integrity:     sha512-Kh1fkEegpd7g/[...]DsYFxFSDeVFEw==
npm notice total files:   32                                      
npm notice 
```

After:

```
npm notice 
npm notice 📦  spectacle-cli@0.5.0
npm notice === Tarball Contents === 
npm notice 60B   lib/templates/boilerplate/_gitignore
npm notice 180B  lib/templates/js-slides/index.html  
npm notice 180B  lib/templates/md-slides/index.html  
npm notice 180B  lib/templates/mdx-slides/index.html 
npm notice 3.3kB lib/spectacle/actions.js            
npm notice 1.9kB bin/boilerplate/args.js             
npm notice 2.9kB bin/spectacle/args.js               
npm notice 555B  bin/boilerplate/cli.js              
npm notice 671B  bin/spectacle/cli.js                
npm notice 324B  lib/util/file.js                    
npm notice 5.8kB lib/templates/js-slides/index.js    
npm notice 1.1kB lib/templates/md-slides/index.js    
npm notice 1.6kB lib/templates/mdx-slides/index.js   
npm notice 477B  lib/webpack/inject-loader.js        
npm notice 8.6kB lib/boilerplate/modes.js            
npm notice 1.4kB lib/templates/replacements.js       
npm notice 578B  examples/cli-mdx/test-component.js  
npm notice 1.2kB config/webpack.config.cli.js        
npm notice 1.6kB config/webpack.config.js            
npm notice 4.6kB package.json                        
npm notice 1.5kB CHANGELOG.md                        
npm notice 1.0kB lib/templates/boilerplate/README.md 
npm notice 6.4kB README.md                           
npm notice 626B  examples/cli-md/slides.md           
npm notice 1.1kB examples/cli-mdx/slides.mdx         
npm notice 1.1kB LICENSE.txt                         
npm notice === Tarball Details === 
npm notice name:          spectacle-cli                           
npm notice version:       0.5.0                                   
npm notice filename:      spectacle-cli-0.5.0.tgz                 
npm notice package size:  15.3 kB                                 
npm notice unpacked size: 48.8 kB                                 
npm notice shasum:        f6e534dda52648c61165d0899401e9dddf4cc4c8
npm notice integrity:     sha512-FAT7VV0SVEP02[...]u1Dq4zxpTPupg==
npm notice total files:   26                  
```