### PR TITLE
Provide theme template defaults.

### DIFF
--- a/lib/spectacle/actions.js
+++ b/lib/spectacle/actions.js
@@ -12,8 +12,10 @@ const {
   modes,
   themeRe,
   themeTmpl,
+  themeDefault,
   templateRe,
   templateTmpl,
+  templateDefault,
   getTmplDir
 } = require('../templates/replacements');
 
@@ -56,18 +58,21 @@ const webpackConfig = async ({
                     pattern: modes[srcMode].re,
                     replacement: modes[srcMode].tmpl(srcFilePath)
                   },
-                  templateFilePath
-                    ? {
-                        pattern: templateRe,
-                        replacement: templateTmpl(templateFilePath)
-                      }
-                    : null,
-                  themeFilePath
-                    ? {
-                        pattern: themeRe,
-                        replacement: themeTmpl(themeFilePath)
-                      }
-                    : null
+                  // **Note**: If a user doesn't provide a template/theme file
+                  // then we do an empty default value instead of whatever
+                  // is originally in the example.
+                  {
+                    pattern: templateRe,
+                    replacement: templateFilePath
+                      ? templateTmpl(templateFilePath)
+                      : templateDefault()
+                  },
+                  {
+                    pattern: themeRe,
+                    replacement: themeFilePath
+                      ? themeTmpl(themeFilePath)
+                      : themeDefault()
+                  }
                 ].filter(Boolean)
               }
             }

--- a/lib/templates/replacements.js
+++ b/lib/templates/replacements.js
@@ -31,11 +31,21 @@ const themeTmpl = themeFilePath => `
 import theme from '${themeFilePath}';
 // SPECTACLE_CLI_THEME_END
 `;
+const themeDefault = () => `
+// SPECTACLE_CLI_THEME_START
+const theme = {};
+// SPECTACLE_CLI_THEME_END
+`;
 
 const templateRe = /\/\/ SPECTACLE_CLI_TEMPLATE_START[\s\S]*?\/\/ SPECTACLE_CLI_TEMPLATE_END/gm;
 const templateTmpl = templateFilePath => `
 // SPECTACLE_CLI_TEMPLATE_START
 import template from '${templateFilePath}';
+// SPECTACLE_CLI_TEMPLATE_END
+`;
+const templateDefault = () => `
+// SPECTACLE_CLI_TEMPLATE_START
+const template = undefined;
 // SPECTACLE_CLI_TEMPLATE_END
 `;
 
@@ -72,7 +82,9 @@ module.exports = {
   },
   themeRe,
   themeTmpl,
+  themeDefault,
   templateRe,
   templateTmpl,
+  templateDefault,
   getTmplDir
 };


### PR DESCRIPTION
For `spectacle-cli` presentations, completely remove any example `template` or `theme` values so user has full control with defaults.