### PR TITLE
Update default branch name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 
 branches:
   only:
-    - master
+    - main
 
 install:
   # Fail if lockfile outdated.

--- a/lib/templates/boilerplate/README.md
+++ b/lib/templates/boilerplate/README.md
@@ -10,7 +10,7 @@ Spectacle Boilerplate
 
 ## Reference
 
-The Spectacle core API is available in the [Spectacle Docs](https://github.com/FormidableLabs/spectacle/blob/master/README.md).
+The Spectacle core API is available in the [Spectacle Docs](https://github.com/FormidableLabs/spectacle/blob/main/README.md).
 
 ## Getting Started
 
@@ -31,7 +31,7 @@ The Spectacle core API is available in the [Spectacle Docs](https://github.com/F
 
 ## Tutorial
 
-If want you a step-by-step guide for getting started with Spectacle, a basic tutorial is available [here](https://github.com/FormidableLabs/spectacle/blob/master/docs/tutorial.md).
+If want you a step-by-step guide for getting started with Spectacle, a basic tutorial is available [here](https://github.com/FormidableLabs/spectacle/blob/main/docs/tutorial.md).
 
 ## Build & Deployment
 


### PR DESCRIPTION
This PR changes the default branch name from `master` to `main` and updates all outdated URLs accordingly.